### PR TITLE
Add `as` option for aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ paq 'nvim-lua/lsp_extensions.nvim'
 
 paq{'lervag/vimtex', opt=true}     -- Use braces when passing options
 
+-- Use as to override the default package name (here `vim`)
+paq{'dracula/vim', as='dracula'}
+
 EOF
 ```
 
@@ -62,6 +65,7 @@ inside a Lua chunk (or in a separate Lua module).
 
 | Option | Type     |                                                           |
 |--------|----------|-----------------------------------------------------------|
+| as     | string   | Name to use for the package                               |
 | branch | string   | Branch of the repository                                  |
 | hook   | string   | Shell command to run after install/update                 |
 | hook   | function | Lua function to run after install/update                  |

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -120,6 +120,16 @@ as long as the name of the repository is the first thing on the table.
 
 The options are the following:
 
+`as`
+  String indicating the alias or name of the plugin, which determines the name
+  of the directory where Paq will download the plugin.
+
+  If left unspecified, Paq will infer it from the plugin string. For
+  `'<GitHub-username>/<repo-name>'` that is `<repo-name>`.
+
+  Default value: `nil`
+
+
 `branch`
   String with the name of a branch of the git repository. If set,
   Paq will only download that specific branch.

--- a/lua/paq-nvim.lua
+++ b/lua/paq-nvim.lua
@@ -119,7 +119,7 @@ local function paq(args)
 
     num_pkgs = num_pkgs + 1
 
-    local reponame = args[1]:match(REPO_RE)
+    local reponame = args.as or args[1]:match(REPO_RE)
     if not reponame then
         return output_result(num_pkgs, num_pkgs, 'parse', args[1])
     end


### PR DESCRIPTION
Since I neglected to create an issue before this PR, here is an overview of the changes.

`paq` has a new option called `as` which overrides `paq`'s name parsed from the repo. It also allows users to install plugins with the same name or otherwise ambiguous names (e.g. [dracula/vim](https://github.com/dracula/vim)).

This change was inspired by packer.nvim's `as` option.

### Old Summary

This changes the way users install plugins from not-GitHub URLs to make it more intuitive. Currently, to install non-GitHub plugins a user must provide a pseudo-GitHub repo and then the full URL. This changes it so they provide the full URL and then the name of the plugin. So for example installing `https://example.com/vim-plugin.git`,
```lua
-- Old way with url
paq {'foo/vim-plugin', url = 'https://example.com/vim-plugin.git'}
-- New way with as
paq {'https://example.com/vim-plugin.git', as = 'vim-plugin'}
```

It also allows users to install plugins with the same name or otherwise ambiguous names (e.g. [dracula/vim](https://github.com/dracula/vim)).

This syntax is similar to what `packer.nvim` does.

I made this change when implementing local plugins for paq. But I abandoned that idea because I think it is (or at least should be) out of scope for paq, since a user can just make a `pack/local/{start,opt}` directory for any local plugins that they want to manage manually with symlinks.