### PR TITLE
Fix PaqInstall

### DIFF
--- a/lua/paq-nvim.lua
+++ b/lua/paq-nvim.lua
@@ -39,7 +39,7 @@ end
 -- Warning: This mutates dst!
 local function list_extend(dst, src, start, finish)
     if vim.api.nvim_call_function('has', {'nvim-0.5'}) == 1 then
-        return vim.list_extend(func, t)
+        return vim.list_extend(dst, src, start, finish)
     else
         -- TODO: validation?
         for i = start or 1, finish or #src do


### PR DESCRIPTION
The call to `vim.list_extend` in `list_extend` didn't had the correct arguments, causing `:PaqInstall` to break.
Looks like PR#12 reused the code from `tbl_map`