### PR TITLE
Add a `PaqList` command

### DIFF
--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -117,6 +117,13 @@ imported as `Paq`, the functions are:
   configuration.
 
 
+|Paq.list|                                                          *Paq.list*
+                                                                  *:PaqList*
+  Lists installed packages as well as packages that were recently removed.
+  Recently installed or updated packages are marked with a `+` and `*`,
+  respectively.
+
+
 |Paq.log_open|                                                  *Paq.log_open*
                                                                *:PaqLogOpen*
   Opens the |paq-log| file in a split window.

--- a/plugin/paq-nvim.vim
+++ b/plugin/paq-nvim.vim
@@ -5,6 +5,7 @@ endif
 command! PaqInstall  lua require('paq-nvim').install()
 command! PaqUpdate   lua require('paq-nvim').update()
 command! PaqClean    lua require('paq-nvim').clean()
+command! PaqList     lua require('paq-nvim').list()
 command! PaqLogOpen  lua require('paq-nvim').log_open()
 command! PaqLogClean lua require('paq-nvim').log_clean()
 


### PR DESCRIPTION
### Summary
This adds a `PaqList` command as proposed in Issue #21 that lists installed packages
as well as recently uninstalled ones. Packages that were recently installed or updated
are prefixed with a `+` and `*`, respectively. The formatting is currently 
```
Installed packages:
    package1
   +package2
   *package3
    ...
Recently removed:
    removed_package
    ...
```
but can be easily changed.

### Tracking Changes
Changes are now tracked in the `changes` table which consists of `'name':'change'`
pairs, where `'change'` is either `'installed'`, `'updated'` or `'removed'`.

To update this table as well as the `packages[name].exists` fields on successful
installations and updates, the `call_proc`function now takes an optional callback function.

Since marking all packages as updated after running `PaqUpdate` is not very useful,
the `PaqUpdate` command now keeps track of if a `git pull` command changed the
corresponding repository (which can also be used to address Issue #8 in the future).
This is done by comparing the hashes of the current commits before and after 
running `git pull`; the function `git_hash(dir)`  was added to retrieve those hashes.

### Misc
The functions `_nvim.tbl_keys` and `_nvim.tbl_filter` were added to retain `0.4`
compatibility