### PR TITLE
Add callable metamethod. Update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+Visit the [releases page](https://github.com/savq/paq-nvim/releases) for more details.
+
+# Deprecations
+
+
+### v0.8.0.
+
+Calling the `paq` function per package is deprecated. Users should now pass a
+list to the `'paq-nvim'` module instead. See the readme and documentation for
+more details.
+
+### v0.6.0.
+
+The `hook` option is deprecated, and will be removed in Paq 1.0. Use `run` instead.
+

--- a/README.md
+++ b/README.md
@@ -39,20 +39,18 @@ In your init.vim or init.lua, you can write something like:
 
 ```lua
 lua << EOF
+require 'paq-nvim' {
+  -- Add your packages
+  'savq/paq-nvim';                  -- Let Paq manage itself
 
-local paq = require'paq-nvim'.paq  -- Import module and bind `paq` function
-paq 'savq/paq-nvim'                -- Let Paq manage itself
+  'neovim/nvim-lspconfig';          -- Mind the semi-colons
+  'nvim-lua/completion-nvim';
+  'nvim-lua/lsp_extensions.nvim';
 
--- Add your packages
+  {'lervag/vimtex', opt=true};      -- Use braces when passing options
 
-paq 'neovim/nvim-lspconfig'
-paq 'nvim-lua/completion-nvim'
-paq 'nvim-lua/lsp_extensions.nvim'
-
-paq{'lervag/vimtex', opt=true}     -- Use braces when passing options
-
-paq{'dracula/vim', as='dracula'}   -- Use `as` to alias a package name (here `vim`)
-
+  {'dracula/vim', as='dracula'};    -- Use `as` to alias a package name (here `vim`)
+}
 EOF
 ```
 
@@ -60,6 +58,10 @@ Then, run `:PaqInstall`.
 
 In general, to add packages to Paq's list, call `paq '<gh-username>/<repo>'`
 inside a Lua chunk (or in a separate Lua module).
+
+**NOTICE:**
+Calling the `paq` function per package is deprecated. Users should now pass a
+list to the `'paq-nvim'` module instead.
 
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Paq is a Neovim package manager written in Lua.
 
 - __Simple__: Easy to use and configure
 - __Fast__:   Installs and updates packages concurrently using Neovim's event-loop
-- __Small__:  Around 150 LOC
+- __Small__:  Around 250 LOC
 
 
 ## Requirements

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -58,17 +58,18 @@ USAGE                                                              *paq-usage*
 
 To get started with Paq:
 
- 1. Import the `paq-nvim` module, and bind the `paq` function:
+ 1. Import the `paq-nvim` module:
  >
-    local Paq = require'paq-nvim'    -- Module
-    local paq = Paq.paq              -- Function
-    paq 'savq/paq-nvim'              -- Paq manages itself
+    local paq = require 'paq-nvim'    -- Module
 <
 
- 2. List the packages you want to install using the `paq` function with the
-    name of a package repository, for example:
+ 2. Call the paq module with a the list of packages you want to install.
+    each entry in the list is a package repository, for example:
 >
-    paq 'lervag/vimtex'
+    paq {
+      'savq/paq-nvim';               -- Paq manages itself
+      'lervag/vimtex';
+    }
 <
 
  3. Run the `:PaqInstall` command.
@@ -82,69 +83,75 @@ FUNCTIONS AND COMMANDS                                          *paq-commands*
 
 The Paq module exports multiple functions. Most of these functions have a
 command alias to make them easier to call on demand. Assuming the module is
-imported as `Paq`, the functions are:
+imported as `paq`, the functions are:
 
-|Paq.paq|                                                            *Paq.paq*
+|paq.__call|                                                      *paq.__call*
 
-  Add a package to Paq's (internal) list. It can take a table or a string.
-  When a table is passed, the first value has to be a string with the name of
-  the repository, like: `'<GitHub-username>/<repository-name>'`.
+  The `paq` module is itself a callable object. It takes as argument a list of
+  packages. Each element of the list can be a table or a string.
+
+  When the element is a table, the first value has to be a string with the
+  name of the repository, like: `'<GitHub-username>/<repository-name>'`.
   The other key-value pairs in the table have to be named explicitly, see
-  |paq-options|. If only a string is passed, it works as if it was the first
+  |paq-options|. When the element is a string, it works as if it was the first
   value of the table, and all other options will be set to their default
   values.
 
-  Note: Lua can elide parentheses when passing a table or a string to a
-  function, so you can always call `paq` without parentheses.
+  Note: Lua can elide parentheses when passing a table to a function,
+  so you can always call `paq` without parentheses.
 
 
-|Paq.install|                                                    *Paq.install*
+|paq.install|                                                    *paq.install*
                                                                *:PaqInstall*
   Installs all packages listed on your configuration, if a package is already
   installed, the function ignores it.
 
 
-|Paq.update|                                                      *Paq.update*
+|paq.update|                                                      *paq.update*
                                                                 *:PaqUpdate*
   Updates the installed packages listed on your configuration. If a package
   hasn't been installed with |PaqInstall|, the function ignores it.
 
 
-|Paq.clean|                                                        *Paq.clean*
+|paq.clean|                                                        *paq.clean*
                                                                  *:PaqClean*
   Removes packages found on |paq-dir| that aren't listed in your
   configuration.
 
 
-|Paq.list|                                                          *Paq.list*
+|paq.list|                                                          *paq.list*
                                                                   *:PaqList*
   Lists installed packages as well as packages that were recently removed.
   Recently installed or updated packages are marked with a `+` and `*`,
   respectively.
 
 
-|Paq.log_open|                                                  *Paq.log_open*
+|paq.log_open|                                                  *paq.log_open*
                                                                *:PaqLogOpen*
   Opens the |paq-log| file in a split window.
 
 
-|Paq.log_clean|                                                *Paq.log_clean*
+|paq.log_clean|                                                *paq.log_clean*
                                                               *:PaqLogClean*
   Deletes the |paq-log| file.
 
 
-|Paq.setup|                                                        *Paq.setup*
+|paq.setup|                                                        *paq.setup*
 
   Configures specific global behavior. It takes as single input a table,
   which can have a key `path` to overwrite the default value for |paq-dir|.
   This functionality exists mainly to allow testing without altering a
   user's configuration.
 
+|paq.paq|                                                            *paq.paq*
+
+  The paq function is deprecated. The `paq` module is now a callable that
+  takes a list of packages.
 
 ==============================================================================
 PACKAGE OPTIONS                                                  *paq-options*
 
-You can pass a table with named options to the |Paq.paq| function.
+Each element in the list of packages can be a table with named options.
 These options don't need to be in any particular order, as long as the
 name of the repository is the first element on the table.
 
@@ -212,7 +219,10 @@ The language client `coc.nvim` recommends installing the release branch of
 their repository. If we also wanted to install it as an optional package,
 we could call `paq` like:
 >
-    paq {'neoclide/coc.nvim', opt=true, branch='release'}
+    local paq = require 'paq-nvim'
+    paq {
+        {'neoclide/coc.nvim', opt=true, branch='release'};
+    }
 <
 
 ==============================================================================
@@ -225,7 +235,7 @@ where Paq installs packages by running the command:
     :echo stdpath('data') .. '/site/pack/paqs'
 <
 If you have packages that aren't managed by Paq, you shouldn't put them on
-Paq's directory, since |Paq.clean| could delete them.
+Paq's directory, since |paq.clean| could delete them.
 
 
 ==============================================================================
@@ -254,12 +264,15 @@ load a local plugin, namely:
 - Add it to a directory in |packpath| (different from |paq-dir|)
 - Modify the |runtimepath| directly
 
+The first option is the easiest, though your plugin can end up pretty deep
+in a directory hierarchy.
+
 The second option just requires you to concatenate the path to the plugin to
-your `runtimepath`. In lua, this looks like:
+your `runtimepath`. In Lua (nvim 0.5), this looks like:
 >
-    vim.o.runtimepath = vim.o.runtimepath .. ",~/path/to/your/plugin"
+    vim.opt.runtimepath:append("~/path/to/your/plugin")
 <
-Use an absolute path, and don't forget the comma!
+Remember to use an absolute path.
 
 
 ------------------------------------------------------------------------------
@@ -286,7 +299,9 @@ writing there isn't a way to declare an autocommand using only Lua.
 
 Example:
 >
-    paq {'author/heavy-plugin', opt=true}
+    paq {
+      {'author/heavy-plugin', opt=true};
+    }
     vim.cmd [[autocmd Filetype ruby packadd! heavy-plugin]]
 <
 

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -1,4 +1,4 @@
-*paq-nvim.txt*  Package manager for Neovim v0.4.4      Last change: 2021-04-05
+*paq-nvim.txt*  Package manager for Neovim v0.4.4      Last change: 2021-06-02
 *paq-nvim*
 *paq*
 
@@ -64,7 +64,7 @@ To get started with Paq:
 <
 
  2. Call the paq module with a the list of packages you want to install.
-    each entry in the list is a package repository, for example:
+    Each entry in the list is a package repository, for example:
 >
     paq {
       'savq/paq-nvim';               -- Paq manages itself

--- a/lua/paq-nvim.lua
+++ b/lua/paq-nvim.lua
@@ -256,4 +256,4 @@ return setmetatable({
     paq       = register, -- DEPRECATE 1.0
     log_open  = function() cmd('sp ' .. LOGFILE) end,
     log_clean = function() uv.fs_unlink(LOGFILE); print('Paq log file deleted') end,
-},{__call=function(self, tbl) packages={} compat.tbl_map(register, tbl) return self end})
+},{__call=function(self, tbl) packages={} num_pkgs=0 compat.tbl_map(register, tbl) return self end})

--- a/lua/paq-nvim.lua
+++ b/lua/paq-nvim.lua
@@ -216,7 +216,7 @@ local function list()
     list_pkgs('Recently removed:', removed)
 end
 
-local function paq(args)
+local function register(args)
     local name, dir
     if type(args) == 'string' then args = {args} end
 
@@ -234,25 +234,26 @@ local function paq(args)
         branch = args.branch,
         dir    = dir,
         exists = (vfn('isdirectory', {dir}) ~= 0),
-        run    = args.run or args.hook, --wait for paq 1.0 to deprecate
+        run    = args.run or args.hook, -- DEPRECATE 1.0
         url    = args.url or 'https://github.com/' .. args[1] .. '.git',
     }
 end
 
-local function setup(args)
+local function setup(self, args)
     assert(type(args) == 'table')
     if type(args.path) == 'string' then
         paq_dir = args.path
     end
+    return self
 end
 
-return {
+return setmetatable({
     install   = function() compat.tbl_map(install, packages) end,
     update    = function() compat.tbl_map(update, packages) end,
     clean     = clean,
     list      = list,
     setup     = setup,
-    paq       = paq,
+    paq       = register, -- DEPRECATE 1.0
     log_open  = function() cmd('sp ' .. LOGFILE) end,
     log_clean = function() uv.fs_unlink(LOGFILE); print('Paq log file deleted') end,
-}
+},{__call=function(self, tbl) packages={} compat.tbl_map(register, tbl) return self end})


### PR DESCRIPTION
The metamethod permits to use Paq with less boilerplate. It also correctly updates the list of packages when a configuration is re-sourced (no more problems with the Lua package's cache).

The old `paq` function still works.

TODO:
- ~update tests~
- update wiki