### PR TITLE
Check if plugin exists before cloning it

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -31,6 +31,21 @@ local messages = {
     }
 }
 
+-- VVV modifications below VVV
+
+--[[
+    Run a process, read it's output and "somehow" get it's return code
+--]]
+function repo_exists(repo)
+    local command = 'curl --head --silent --fail https://github.com/' .. repo .. ' > /dev/null'
+    local process = io.popen(command)
+    local output = process:read('*all')
+    local rc = process:close()
+    return rc ~= nil and true or false
+end
+
+-- ^^^ modifications above ^^^
+
 local function Counter(op) counters[op] = {ok=0, err=0, nop=0} end
 
 local function update_count(op, result, _, total)
@@ -100,7 +115,8 @@ local function install(pkg)
         end
         report("install", ok and "ok" or "err", pkg.name)
     end
-    call_proc("git", args, nil, post_install)
+    local repo_is_up = repo_exists('henriquehbr/svelte-typewriter')
+    repo_is_up and call_proc("git", args, nil, post_install) or report("install", "err", pkg.name)
 end
 
 local function get_git_hash(dir)

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -31,8 +31,6 @@ local messages = {
     }
 }
 
--- VVV modifications below VVV
-
 --[[
     Run a process, read it's output and "somehow" get it's return code
 --]]
@@ -52,8 +50,6 @@ local function url_exists(url)
 
     return tonumber(exit_code) == 0 and true or false
 end
-
--- ^^^ modifications above ^^^
 
 local function Counter(op) counters[op] = {ok=0, err=0, nop=0} end
 
@@ -124,13 +120,11 @@ local function install(pkg)
         end
         report("install", ok and "ok" or "err", pkg.name)
     end
-    -- VVV modifications below VVV
     if url_exists(pkg.url) then
         call_proc("git", args, nil, post_install)
     else
         report("install", "err", pkg.name)
     end
-    -- ^^^ modification below ^^^
 end
 
 local function get_git_hash(dir)


### PR DESCRIPTION
Closes #59

Basically what it does is run `curl` for checking whether the given plugin URL returns 404 or not, returning an error message warning the user that the given plugin could not be installed, avoiding the screen freeze