### PR TITLE
fix to stop removing paq-nvim directory

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -149,10 +149,12 @@ local function remove(packdir)
         end
     end
     for name, dir in pairs(to_rm) do
-        call_proc("rm", {"-r", "-f", dir}, packdir, function(ok)
-            last_ops[name] = "remove"
-            report("remove", ok and "ok" or "err", name, c)
-        end)
+        if name ~= "paq-nvim" then
+            call_proc("rm", {"-r", "-f", dir}, packdir, function(ok)
+                last_ops[name] = "remove"
+                report("remove", ok and "ok" or "err", name, c)
+            end)
+        end
     end
 end
 


### PR DESCRIPTION
Fix #63 
Whenever one does a `:PaqClean` and they did not include paq itself via the `paq "savq/paq-nvim"` in their init.lua, then that command will delete paq itself, this fix prevents that.