### PR TITLE
Fixes For PaqClean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# to tag files
+doc/tags

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -149,10 +149,12 @@ local function remove(packdir)
         end
     end
     for name, dir in pairs(to_rm) do
-        call_proc("rm", {"-r", "-f", dir}, packdir, function(ok)
-            last_ops[name] = "remove"
-            report("remove", ok and "ok" or "err", name, c)
-        end)
+        if name ~= "paq-nvim" then
+            call_proc("rm", {"-r", "-f", dir}, packdir, function(ok)
+                last_ops[name] = "remove"
+                report("remove", ok and "ok" or "err", name, c)
+            end)
+        end
     end
 end
 

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -150,14 +150,10 @@ local function remove(packdir)
     end
     for name, dir in pairs(to_rm) do
         if name ~= "paq-nvim" then
-            call_proc("rm", {"-r", "-f", dir}, packdir, function(ok)
-                last_ops[name] = "remove"
-                report("remove", ok and "ok" or "err", name, c)
-            end)
+            vim.fn.delete(dir,"rf")
         end
     end
 end
-
 
 local function list()
     local installed = vim.tbl_filter(function(name) return packages[name].exists end, vim.tbl_keys(packages))


### PR DESCRIPTION
- Fixes issue where PaqClean does nothing on windows #69 
- Fixes PaqClean deleting paq-nvim if user didn't have explicitly stated in `paq ' savq/paq-nvim'` #63 