### PR TITLE
fix clean() not scanning all directories

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -165,7 +165,7 @@ local function check_rm()
     for _, packdir in pairs({ "start", "opt" }) do
         walk_dir(cfg.path .. packdir, function(dir, name)
             if name == "paq-nvim" then
-                return
+                return true
             end
             local pkg = packages[name]
             if not (pkg and pkg.dir == dir) then


### PR DESCRIPTION
fixes clean() behaviour - when scanning for directories to remove, the loop terminates immediately upon reaching paq-nvim, thus not all directories are always scanned and removed as necessary