### PR TITLE
Add single line load() for adding packages

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -271,6 +271,7 @@ return setmetatable({
     list = list,
     log_open = function() vim.cmd("sp " .. LOGFILE) end,
     log_clean = function() return assert(uv.fs_unlink(LOGFILE)) and vim.notify(" Paq: log file deleted") end,
+    load = function(pkg) register(pkg) end,
     paq = register, -- TODO: deprecate. not urgent
 }, {__call = function(self, tbl) packages = {} vim.tbl_map(register, tbl) return self end,
 })

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -271,7 +271,7 @@ return setmetatable({
     list = list,
     log_open = function() vim.cmd("sp " .. LOGFILE) end,
     log_clean = function() return assert(uv.fs_unlink(LOGFILE)) and vim.notify(" Paq: log file deleted") end,
-    load = function(pkg) register(pkg) end,
+    register = function(pkg) register(pkg) end,
     paq = register, -- TODO: deprecate. not urgent
 }, {__call = function(self, tbl) packages = {} vim.tbl_map(register, tbl) return self end,
 })


### PR DESCRIPTION
## About 
Adds the ability to add packages one at a time, as requested in #88. 

Honestly, I think it is better to load all plugins in a `plugins.lua` file, then create a `<plugin>.lua` file for the configuration of that plugin, but you could use this fork if need be.

## Configuration
```lua
local paq = require("paq")
paq.load("<package>")
```

### Example usage
Say you wanted to load [tpope/vim-surround](https://github.com/tpope/vim-surround), then you could do the following:

```lua
require("paq").load("tpope/vim-surround")

-- or
local paq = require("paq")
paq.load("tpope/vim-surround")
```
