### PR TITLE
Update `hrsh7th/nvim-compe` to `hrsh7th/nvim-cmp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ require "paq" {
     "savq/paq-nvim";                  -- Let Paq manage itself
 
     "neovim/nvim-lspconfig";          -- Mind the semi-colons
-    "hrsh7th/nvim-compe";
+    "hrsh7th/nvim-cmp";
 
     {"lervag/vimtex", opt=true};      -- Use braces when passing options
 }

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -62,7 +62,7 @@ To get started with Paq:
 
         "neovim/nvim-lspconfig";
         "nvim-treesitter/nvim-treesitter"
-        "hrsh7th/nvim-compe";
+        "hrsh7th/nvim-cmp";
         "lervag/vimtex";
     }
 <


### PR DESCRIPTION
`hrsh7th/nvim-compe` was archived. The new repository is `hrsh7th/nvim-cmp`.