### PR TITLE
fix: Don't try to clone existing pinned packages

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -152,7 +152,7 @@ end
 local function clone_or_pull(pkg, counter)
     if pkg.exists and not pkg.pin then
         pull(pkg, counter, "update")
-    else
+    elseif not pkg.exists then
         clone(pkg, counter, "install")
     end
 end


### PR DESCRIPTION
When you call `PaqSync` and have a pinned package that has already been installed, paq will attempt to re-clone it and will throw an error since git will complain about the directory already existing. This PR fixes the issue.