### PR TITLE
Re-implement log updated packages commits fixing out of order bug.

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -74,12 +74,6 @@ local function call_proc(process, args, cwd, cb, print_stdout)
     end
 end
 
-local function log(message)
-    local log = uv.fs_open(logfile, "a+", 0x1A4)
-    uv.fs_write(log, message .. '\n')
-    uv.fs_close(log)
-end
-
 local function run_hook(pkg, counter, sync)
     local t = type(pkg.run)
     if t == "function" then
@@ -131,6 +125,27 @@ local function get_git_hash(dir)
     return head_ref and first_line(dir .. "/.git/" .. head_ref:gsub("ref: ", ""))
 end
 
+local function log_update_changes(pkg, prev_hash, cur_hash)
+    local output = {"\n\n" .. pkg.name .. " updated:\n"}
+    local stdout = uv.new_pipe()
+    local options = {
+        args = {"log", "--pretty=format:* %s", prev_hash .. ".." .. cur_hash},
+        cwd = pkg.dir, stdio = {nil, stdout, nil},
+    }
+    local handle
+    handle, _ = uv.spawn('git', options, function(code)
+        assert(code == 0, "Exited(" .. code .. ")")
+        handle:close()
+        local log = uv.fs_open(logfile, "a+", 0x1A4)
+        uv.fs_write(log, output, nil, nil)
+        uv.fs_close(log)
+    end)
+    stdout:read_start(function(err, data)
+        assert(not err, err)
+        table.insert(output, data)
+    end)
+end
+
 local function pull(pkg, counter, sync)
     local prev_hash = get_git_hash(pkg.dir)
     call_proc("git", { "pull", "--recurse-submodules", "--update-shallow" }, pkg.dir, function(ok)
@@ -139,8 +154,7 @@ local function pull(pkg, counter, sync)
         else
             local cur_hash = get_git_hash(pkg.dir)
             if cur_hash ~= prev_hash then
-                log(pkg.name .. " updating...")
-                call_proc("git", { "log", "--pretty=format:* %s", prev_hash .. ".." .. cur_hash }, pkg.dir, function(ok) end, true)
+                log_update_changes(pkg, prev_hash, cur_hash)
                 pkg.status = "updated"
                 return pkg.run and run_hook(pkg, counter, sync) or counter(pkg.name, "ok", sync)
             else


### PR DESCRIPTION
Hi there,

Learned some libuv/luv
Re-implemented this feature using a table to place all outputs before write into log file.

Also added line breaking.
Here is the print of how it looks now. Please tell me if it should look different.
Or if code is not in pattern for this project.

![image](https://user-images.githubusercontent.com/1062631/180340450-40ab4fda-e443-434b-942d-6e357e2c6c0e.png)
