### PR TITLE
Fix a bug in the counter coroutine

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -51,6 +51,7 @@ local function new_counter()
         vim.notify(summary:format(op, c.ok, c.err, c.nop))
         vim.cmd("packloadall! | silent! helptags ALL")
         vim.cmd("doautocmd User PaqDone" .. op:gsub("^%l", string.upper))
+        return true
     end)
 end
 


### PR DESCRIPTION
This pull request fixes #98 and fixes #112.
The issue is that when `counter` happens to get called for the last time by `run_hook`, the coroutine terminates and returns `nil`, rather than returning `true` which is expected from `coroutine.yield(true)`. Therefore, `run_hook` ends up returning `nil` [here](https://github.com/savq/paq-nvim/blob/b3c7d047e29792f306626bf87430a2b0c92e5aad/lua/paq.lua?plain=1#L89) which causes `counter` to be called again in `clone` [here](https://github.com/savq/paq-nvim/blob/b3c7d047e29792f306626bf87430a2b0c92e5aad/lua/paq.lua?plain=1#L114). This resumes a dead coroutine, hence the error.
This PR fixes this by returning `true` at the end of the coroutine, which seems to be the intended behavior.