### PR TITLE
Allow using URL as string

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -267,6 +267,9 @@ local function register(args)
     if type(args) == "string" then
         args = { args }
     end
+    if not args.url and args[1]:match("^https?://") then
+        args.url = args[1]
+    end
     local name, src = parse_name(args)
     if not name then
         return vim.notify(" Paq: Failed to parse " .. src, vim.log.levels.ERROR)


### PR DESCRIPTION
Enable using plain URLs directly, rather than needing to explicitly write {url="..."} for each one (which gets a bit noisy).

This enables the following usage:

```lua
require 'paq' {
    "https://github.com/savq/paq-nvim",
}
```
