### PR TITLE
feat: opt in setup function as default plugin location instead of start (#131)

### DIFF
--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -163,6 +163,13 @@ imported as `paq`, the functions are:
 
     Default value: |paq-dir|
 
+    `opt`
+    Boolean that changes if, by default, plugins are eagerly loaded or lazy
+    loaded. If set, the package will be in the optional packages
+    directory. See |packages| and |packadd|.
+
+    Default value: `false`
+
     `verbose`
     Boolean that determines whether paq should print `(up-to-date) pkg` for
     packages that were not updated.
@@ -306,7 +313,7 @@ PAQ AUTOCOMMANDS                                            *paq-autocommands*
 
 Paq provides |User| events for its async operations, each event has the name
 `PaqDone` followed by the name of an operation:
- 
+
     `PaqDoneInstall` run after `PaqInstall`
     `PaqDoneUpdate` runs after `PaqUpdate`
     `PaqDoneSync` runs after `PaqSync`

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -277,10 +277,8 @@ local function register(args)
     elseif packages[name] then
         return
     end
-    if (args.opt == nil or args.opt) and cfg.opt then
-        args.opt = true
-    end
-    local dir = cfg.path .. (args.opt and "opt/" or "start/") .. name
+    local opt = (args.opt == nil or args.opt) and cfg.opt
+    local dir = cfg.path .. (opt and "opt/" or "start/") .. name
     packages[name] = {
         name = name,
         branch = args.branch,

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -1,6 +1,7 @@
 local uv = vim.loop
 local cfg = {
     path = vim.fn.stdpath("data") .. "/site/pack/paqs/",
+    opt = false,
     verbose = false,
 }
 local logpath = vim.fn.has("nvim-0.8") == 1 and vim.fn.stdpath("log") or vim.fn.stdpath("cache")
@@ -275,6 +276,9 @@ local function register(args)
         return vim.notify(" Paq: Failed to parse " .. src, vim.log.levels.ERROR)
     elseif packages[name] then
         return
+    end
+    if (args.opt == nil or args.opt) and cfg.opt then
+        args.opt = true
     end
     local dir = cfg.path .. (args.opt and "opt/" or "start/") .. name
     packages[name] = {


### PR DESCRIPTION
This make it so that if you use the method `opt` in the setup function all the packages will be installed by default in the opt directory, without specifying `opt = true` for all packages. Also if for whatever reason the user want some packages still in the start directory could pass `opt=false` and the package will be installed in the start directory.