### PR TITLE
feat: execute run hook as vim command if first char is ':'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ require "paq" {
 
     { "lervag/vimtex", opt = true }, -- Use braces when passing options
 
-    { 'nvim-treesitter/nvim-treesitter', run = function() vim.cmd 'TSUpdate' end },
+    { 'nvim-treesitter/nvim-treesitter', run = ':TSUpdate' },
 }
 ```
 

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -256,7 +256,8 @@ The options and their types are the following:
   updating a package. Useful for packages that require extra build steps.
 
   If a string, Paq will execute the string as a shell command in the
-  directory of the package (not in the current directory).
+  directory of the package (not in the current directory). If the first
+  character of the string is a `:`, it will be execute as vim `:command`
 
   If a function, Paq will execute the function right after installing
   the package. The function cannot take any arguments.

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -89,14 +89,18 @@ local function run_hook(pkg, counter, sync)
         return counter and counter(pkg.name, res, sync)
     elseif t == "string" then
         local args = {}
-        for word in pkg.run:gmatch("%S+") do
-            table.insert(args, word)
+        if pkg.run:sub(1, 1) == ":" then
+            vim.cmd(pkg.run)
+        else
+            for word in pkg.run:gmatch("%S+") do
+                table.insert(args, word)
+            end
+            call_proc(table.remove(args, 1), args, pkg.dir, function(ok)
+                local res = ok and "ok" or "err"
+                report("hook", pkg.name, res)
+                return counter and counter(pkg.name, res, sync)
+            end)
         end
-        call_proc(table.remove(args, 1), args, pkg.dir, function(ok)
-            local res = ok and "ok" or "err"
-            report("hook", pkg.name, res)
-            return counter and counter(pkg.name, res, sync)
-        end)
         return true
     end
 end


### PR DESCRIPTION
fixes: #142

Now you can pass to the run function a string prepended with a `:` and will be run as a vim `:command`. This is actually how packer behave so this could be a nice to behave as the user expect.