### PR TITLE
Refactor code: Update minimum requirements to nvim 0.7

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ Paq is a Neovim package manager written in Lua.
 
 ## Requirements
 
+> **NOTE**
+> Paq follows the [Neovim version available in Debian stable](https://packages.debian.org/stable/editors/neovim).
+
 - git
-- [Neovim](https://github.com/neovim/neovim) ≥ 0.5
+- [Neovim](https://github.com/neovim/neovim) ≥ 0.7
 
 
 ## Installation
@@ -53,6 +56,7 @@ require "paq" {
 ```
 
 Then, source your configuration (using `:source %` or `:luafile %`) and run `:PaqInstall`.
+
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,6 @@ require "paq" {
 
 Then, source your configuration (using `:source %` or `:luafile %`) and run `:PaqInstall`.
 
-
-**NOTICE:**
-Calling the `paq` function per package is deprecated. Users should now pass a list to the `"paq"` module instead.
-
-
 ## Commands
 
 - `PaqInstall`: Install all packages listed in your configuration.

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -195,12 +195,6 @@ imported as `paq`, the functions are:
     "neovim/nvim-lspconfig",
     "nvim-treesitter/nvim-treesitter",
   }
-<
-
-|paq.paq|
-
-  The paq function is deprecated. The `paq` module is now a callable that
-  takes a list of packages.
 
 
 ==============================================================================

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -327,28 +327,27 @@ local function list()
     end
 end
 
-local function register(args)
-    if type(args) == "string" then
-        args = { args }
+local function register(pkg)
+    if type(pkg) == "string" then
+        pkg = { pkg }
     end
-    local url = args.url
-        or (args[1]:match("^https?://") and args[1])    -- [1] is a URL
-        or string.format(cfg.url_format, args[1])       -- [1] is a repository name
-    local name = args.as
-        or url:gsub("%.git$", ""):match("/([%w-_.]+)$") -- Infer name from `url`
+    local url = pkg.url
+        or (pkg[1]:match("^https?://") and pkg[1]) -- [1] is a URL
+        or string.format(cfg.url_format, pkg[1]) -- [1] is a repository name
+    local name = pkg.as or url:gsub("%.git$", ""):match("/([%w-_.]+)$") -- Infer name from `url`
     if not name then
-        return vim.notify(" Paq: Failed to parse " .. vim.inspect(args), vim.log.levels.ERROR)
+        return vim.notify(" Paq: Failed to parse " .. vim.inspect(pkg), vim.log.levels.ERROR)
     end
-    local opt = args.opt or cfg.opt and args.opt == nil
+    local opt = pkg.opt or cfg.opt and pkg.opt == nil
     local dir = cfg.path .. (opt and "opt/" or "start/") .. name
     packages[name] = {
         name = name,
-        branch = args.branch,
+        branch = pkg.branch,
         dir = dir,
         status = uv.fs_stat(dir) and status.INSTALLED or status.LISTED,
         hash = get_git_hash(dir),
-        pin = args.pin,
-        run = args.run, -- TODO(breaking): Rename
+        pin = pkg.pin,
+        run = pkg.run, -- TODO(breaking): Rename
         url = url,
     }
 end

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -95,9 +95,15 @@ local function lock_load()
 end
 
 local function state_write()
+   -- remove run key since can have a function in it, and
+    -- json.encode doesn't support functions
+    local pkgs = vim.deepcopy(packages)
+    for p, _ in pairs(pkgs) do
+        pkgs[p].run = nil
+    end
     local file = uv.fs_open(lockfile, "w", 438)
     if file then
-        local ok, result = pcall(vim.json.encode, packages)
+        local ok, result = pcall(vim.json.encode, pkgs)
         if not ok then
             error(result)
         end

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -359,6 +359,5 @@ return setmetatable({
     log_open = function() vim.cmd("sp " .. logfile) end,
     log_clean = function() return assert(uv.fs_unlink(logfile)) and vim.notify(" Paq: log file deleted") end,
     register = register,
-    paq = register, -- TODO: deprecate. not urgent
 }, {__call = function(self, tbl) packages = {} lock = lock_load() or packages vim.tbl_map(register, tbl) return self end,
 })

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -13,8 +13,7 @@ local lock = {}
 
 -- This is done only once. Doing it for every process seems overkill
 local env = {}
-local envfn = vim.fn.has("nvim-0.6") == 1 and uv.os_environ or vim.fn.environ
-for var, val in pairs(envfn()) do
+for var, val in pairs(uv.os_environ()) do
     table.insert(env, string.format("%s=%s", var, val))
 end
 table.insert(env, "GIT_TERMINAL_PROMPT=0")
@@ -200,11 +199,12 @@ local function get_git_hash(dir)
 end
 
 local function log_update_changes(pkg, prev_hash, cur_hash)
-    local output = {"\n\n" .. pkg.name .. " updated:\n"}
+    local output = { "\n\n" .. pkg.name .. " updated:\n" }
     local stdout = uv.new_pipe()
     local options = {
-        args = {"log", "--pretty=format:* %s", prev_hash .. ".." .. cur_hash},
-        cwd = pkg.dir, stdio = {nil, stdout, nil},
+        args = { "log", "--pretty=format:* %s", prev_hash .. ".." .. cur_hash },
+        cwd = pkg.dir,
+        stdio = { nil, stdout, nil },
     }
     local handle
     handle, _ = uv.spawn('git', options, function(code)
@@ -324,8 +324,8 @@ local function register(args)
         args = { args }
     end
     local url = args.url
-        or (args[1]:match("^https?://") and args[1]) -- [1] is a URL
-        or string.format(cfg.url_format, args[1]) -- [1] is a repository name
+        or (args[1]:match("^https?://") and args[1])    -- [1] is a URL
+        or string.format(cfg.url_format, args[1])       -- [1] is a repository name
     local name = args.as
         or url:gsub("%.git$", ""):match("/([%w-_.]+)$") -- Infer name from `url`
     if not name then
@@ -348,16 +348,30 @@ end
 
 -- stylua: ignore
 return setmetatable({
-    install = function() exe_op("install", clone, vim.tbl_filter(function(pkg) return not pkg.exists and pkg.status ~= "removed" end, packages)) end,
-    update = function() exe_op("update", pull, vim.tbl_filter(function(pkg) return pkg.exists and not pkg.pin end, packages)) end,
+    install = function() exe_op("install", clone,
+            vim.tbl_filter(function(pkg) return not pkg.exists and pkg.status ~= "removed" end, packages)) end,
+    update = function() exe_op("update", pull,
+            vim.tbl_filter(function(pkg) return pkg.exists and not pkg.pin end, packages)) end,
     clean = function() exe_op("remove", remove, state_diff().lock) end,
-    sync = function(self) self:clean() exe_op("sync", clone_or_pull, vim.tbl_filter(function(pkg) return pkg.status ~= "removed" end, packages)) end,
-    setup = function(self, args) for k, v in pairs(args) do cfg[k] = v end return self end,
+    sync = function(self)
+        self:clean()
+        exe_op("sync", clone_or_pull, vim.tbl_filter(function(pkg) return pkg.status ~= "removed" end, packages))
+    end,
+    setup = function(self, args)
+        for k, v in pairs(args) do cfg[k] = v end
+        return self
+    end,
     _run_hook = function(name) return run_hook(packages[name]) end,
     _get_hooks = function() return vim.tbl_keys(vim.tbl_map(function(pkg) return pkg.run end, packages)) end,
     list = list,
     log_open = function() vim.cmd("sp " .. logfile) end,
     log_clean = function() return assert(uv.fs_unlink(logfile)) and vim.notify(" Paq: log file deleted") end,
     register = register,
-}, {__call = function(self, tbl) packages = {} lock = lock_load() or packages vim.tbl_map(register, tbl) return self end,
+}, {
+    __call = function(self, tbl)
+        packages = {}
+        lock = lock_load() or packages
+        vim.tbl_map(register, tbl)
+        return self
+    end,
 })


### PR DESCRIPTION
This PR does the following:
- adds `.editorconfig`: for better style consistency (supported natively in neovim 0.9)
- remove deprecated `paq` method
- now is required neovim 0.7 and above
- creates commands with lua api
- track status with Enum like table
  - removing exists key
  - created `filter` table to make it more easy filter packages
- iterating over lockfile functionality