### PR TITLE
Paq 2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -4,3 +4,4 @@ indent_type = "Spaces"
 indent_width = 4
 quote_style = "ForceDouble"
 call_parentheses = "NoSingleTable"
+collapse_simple_statement = "FunctionOnly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ Visit the [releases page](https://github.com/savq/paq-nvim/releases) for more de
 
 # Deprecations
 
+### v2.0.0
+
+- The `run` option was deprecated. Use `build` instead.
+- `:PaqRunHooks` was replaced by `:PaqBuild`.
+- Calling `require(paq).register` directly was removed.
+
+
 ### v1.0.0.
 
 - The `hook` option was removed (use `run` instead).
@@ -9,6 +16,7 @@ Visit the [releases page](https://github.com/savq/paq-nvim/releases) for more de
 - `paq-nvim` module alias was removed. call `require 'paq'` instead.
 
 See #87 for more details.
+
 
 ### v0.9.0.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ require "paq" {
 
     { "lervag/vimtex", opt = true }, -- Use braces when passing options
 
-    { 'nvim-treesitter/nvim-treesitter', run = ':TSUpdate' },
+    { 'nvim-treesitter/nvim-treesitter', build = ':TSUpdate' },
 }
 ```
 
@@ -72,10 +72,10 @@ Then, source your configuration (using `:source %` or `:luafile %`) and run `:Pa
 |--------|----------|-----------------------------------------------------------|
 | as     | string   | Name to use for the package locally                       |
 | branch | string   | Branch of the repository                                  |
+| build  | function | Lua function to run after install/update                  |
+| build  | string   | Shell command to run after install/update                 |
 | opt    | boolean  | Optional packages are not loaded on startup               |
 | pin    | boolean  | Pinned packages are not updated                           |
-| run    | string   | Shell command to run after install/update                 |
-| run    | function | Lua function to run after install/update                  |
 | url    | string   | URL of the remote repository, useful for non-GitHub repos |
 
 For more details on each option, refer to the

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ Paq is a Neovim package manager written in Lua.
 
 ## Requirements
 
+> **NOTE**
+> Paq follows the [Neovim version available in Debian stable](https://packages.debian.org/stable/editors/neovim).
+
 - git
-- [Neovim](https://github.com/neovim/neovim) ≥ 0.5
+- [Neovim](https://github.com/neovim/neovim) ≥ 0.7
 
 
 ## Installation
@@ -53,6 +56,7 @@ require "paq" {
 ```
 
 Then, source your configuration (using `:source %` or `:luafile %`) and run `:PaqInstall`.
+
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,6 @@ require "paq" {
 
 Then, source your configuration (using `:source %` or `:luafile %`) and run `:PaqInstall`.
 
-
-**NOTICE:**
-Calling the `paq` function per package is deprecated. Users should now pass a list to the `"paq"` module instead.
-
-
 ## Commands
 
 - `PaqInstall`: Install all packages listed in your configuration.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Paq is a Neovim package manager written in Lua.
 
 - __Simple__: Easy to use and configure
 - __Fast__:   Installs and updates packages concurrently using Neovim's event-loop
-- __Small__:  Around 250 LOC
+- __Small__:  Around 500 LOC
 
 
 ## Requirements
@@ -74,6 +74,7 @@ Then, source your configuration (using `:source %` or `:luafile %`) and run `:Pa
 | branch | string   | Branch of the repository                                  |
 | build  | function | Lua function to run after install/update                  |
 | build  | string   | Shell command to run after install/update                 |
+| build  | string   | Prefixed with a ':' will run a vim command                |
 | opt    | boolean  | Optional packages are not loaded on startup               |
 | pin    | boolean  | Pinned packages are not updated                           |
 | url    | string   | URL of the remote repository, useful for non-GitHub repos |

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -155,35 +155,52 @@ imported as `paq`, the functions are:
   following keys:
 
     `path`
-    String that determines where Paq should install packages. It overwrites
-    the default value for |paq-dir|. `path` should still be a valid |packages|
-    directory, Paq won't modify the 'runtimepath'. This option exists mainly
-    to allow testing without altering a user's configuration.
+     String that determines where Paq should install packages. It overwrites
+     the default value for |paq-dir|. `path` should still be a valid |packages|
+     directory, Paq won't modify the 'runtimepath'. This option exists mainly
+     to allow testing without altering a user's configuration.
 
-    Default value: |paq-dir|
+     Default value: |paq-dir|
 
     `opt`
-    Boolean that changes if, by default, plugins are eagerly loaded or lazy
-    loaded. If set, the package will be in the optional packages
-    directory. See |packages| and |packadd|.
+     Boolean that changes if, by default, plugins are eagerly loaded or lazy
+     loaded. If set, the package will be in the optional packages directory.
+     See |packages| and |packadd|.
 
-    Default value: `false`
+     Default value: `false`
 
     `url_format`
-    String that determines the format used for constructing the URL of a
-    package repository. It uses the Lua format syntax, and should only receive
-    a single string argument `"%s"` (`[1]` in |paq-options| below).
+     String that determines the format used for constructing the URL of a
+     package repository. It uses the Lua format syntax, and should only
+     receive a single string argument `"%s"` (`[1]` in |paq-options| below).
 
-    This can be set to use SSH instead of HTTPS, to use a different forge
-    than GitHub, etc.
+     This can be set to use SSH instead of HTTPS, to use a different forge
+     than GitHub, etc.
 
-    Default value: `"https://github.com/%s.git"`
+     Default value: `"https://github.com/%s.git"`
 
     `verbose`
-    Boolean that determines whether paq should print `(up-to-date) pkg` for
-    packages that were not updated.
+     Boolean that determines whether paq should print `(up-to-date) pkg` for
+     packages that were not updated.
 
-    Default value: `false`
+     Default value: `false`
+
+    `log`
+     Path to log file.
+
+     Default value: neovim >= 8.0 `XDG_STATE_HOME/nvim/paq`
+                    neovim <= 7.0 `XDG_CACHE_HOME/nvim/paq`
+
+    `lock`
+     Path to lock file. Paq uses a lockfile to represent the current state of
+     the currently installed packages. If doesn't found any lockfile it will
+     create a new one.
+
+    `clone_args`
+     Arguments passed to git clone when cloning a package.
+
+     Default values: --depth=1 --recurse-submodules --shallow-submodules
+                     --no-single-branch
 
   Note that unlike most Lua plugins, paq:setup is a method, not a function.
   This allows chaining it with the list of packages without needing to

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -1,5 +1,5 @@
-*paq-nvim.txt*  Package manager for Neovim >= v0.5.
-*paq-nvim*                                             Last change: 2023-02-08
+*paq-nvim.txt*  Package manager for Neovim >= v0.7.
+*paq-nvim*                                             Last change: 2023-10-20
 *paq*
 
 Author: Sergio Alejandro Vargas    <savargasqu+git@unal.edu.co>

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -100,16 +100,16 @@ imported as `paq`, the functions are:
 |paq.install|                                                    *paq.install*
                                                                *:PaqInstall*
   Installs all packages listed in your configuration. If a package is already
-  installed, the function ignores it. If a package has a `run` argument, it'll
-  be executed after the package is installed.
+  installed, the function ignores it. If a package has a `build` argument,
+  it'll be executed after the package is installed.
 
 
 |paq.update|                                                      *paq.update*
                                                                 *:PaqUpdate*
   Updates the installed packages listed in your configuration. If a package
-  hasn't been installed with |PaqInstall|, the function ignores it.
-  If a package had changes and it has a `run` argument, then the `run`
-  argument will be executed.
+  hasn't been installed with |PaqInstall|, the function ignores it. If a
+  package had changes and it has a `build` argument, then the `build` argument
+  will be executed.
 
 
 |paq.clean|                                                        *paq.clean*
@@ -125,12 +125,11 @@ imported as `paq`, the functions are:
   out of order.
 
 
-|paq._run_hook|                                                *paq._run_hook*
-                                                               *:PaqRunHook*
-  Takes as single argument a string with the name of a package. If the package
-  has a `run` hook (functions and shell commands), it will execute the hook.
-  This can be used when a hook fails, to run a hook without a package having
-  changed, or for other debugging purposes.
+|PaqBuild|                                                         *:PaqBuild*
+  Takes as single argument with the name of a package. If the package has a
+  `build` option (function or shell command), it will execute it. This can be
+  used when a build fails, to run a build without a package having changed, or
+  for other debugging purposes.
 
 
 |paq.list|                                                          *paq.list*
@@ -231,6 +230,26 @@ The options and their types are the following:
   Default value: `nil`
 
 
+`build` : function | string
+  Either a Lua function, a shell command, or an EX-command to be executed
+  after installing or updating a package. Useful for packages that require
+  a compiling step.
+
+  If a string, Paq will execute the string as a shell command in the
+  directory of the package (not in the current directory). If the first
+  character of the string is a `:`, it will be execute as vim `:command`.
+
+  If a function, Paq will execute the function right after installing
+  the package. The function cannot take any arguments.
+
+  Note that in Lua, you can use index notation to reference a VimL function
+  that contains special characters:
+>lua
+  { "<name-of-package>", build = vim.fn["<name-of-viml-function>"] }
+<
+  Default value: `nil`
+
+
 `opt` : boolean
   Indicates whether the package is optional or not. If set, the package will
   be in the optional packages directory. See |packages| and |packadd|.
@@ -246,21 +265,7 @@ The options and their types are the following:
 
 
 `run` : string | function
-  Either a shell command or Lua function to be executed after installing or
-  updating a package. Useful for packages that require extra build steps.
-
-  If a string, Paq will execute the string as a shell command in the
-  directory of the package (not in the current directory). If the first
-  character of the string is a `:`, it will be execute as vim `:command`
-
-  If a function, Paq will execute the function right after installing
-  the package. The function cannot take any arguments.
-
-  Note that in Lua, you can wrap a VimL function like so:
->lua
-  { "<name-of-package>", run = vim.fn["<name-of-viml-function>"] }
-<
-  Default value: `nil`
+  Deprecated. Use `build` instead.
 
 
 `url` : string
@@ -363,7 +368,7 @@ Here's a list of steps to take when something goes wrong with Paq:
   so you might want to look from the bottom up.
 
 4. If you think the error wasn't caused by git (or another external program
-  called with a hook), consider opening an issue on the paq-nvim GitHub
+  called with `build`), consider opening an issue on the paq-nvim GitHub
   repository.
 
 Some common issues are listed below.

--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -195,12 +195,6 @@ imported as `paq`, the functions are:
     "neovim/nvim-lspconfig",
     "nvim-treesitter/nvim-treesitter",
   }
-<
-
-|paq.paq|
-
-  The paq function is deprecated. The `paq` module is now a callable that
-  takes a list of packages.
 
 
 ==============================================================================

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -398,13 +398,13 @@ do
     local build_cmd_opts = {
         bar = true,
         nargs = 1,
-        complete = function() return vim.tbl_keys(vim.tbl_map(function(pkg) return pkg.build end, packages)) end,
+        complete = function() return vim.tbl_keys(vim.tbl_map(function(pkg) return pkg.build end, Packages)) end,
     }
-    vim.api.nvim_create_user_command("PaqBuild", function(a) run_hook(Packages[a.args]) end, build_cmd_opts)
     vim.api.nvim_create_user_command("PaqSync", function() paq:sync() end, { bar = true })
+    vim.api.nvim_create_user_command("PaqBuild", function(a) run_build(Packages[a.args]) end, build_cmd_opts)
     vim.api.nvim_create_user_command("PaqRunHook", function(a)
         vim.deprecate("`PaqRunHook` command", "`PaqBuild`", "3.0", "Paq", false)
-        run_hook(Packages[a.args])
+        run_build(Packages[a.args])
     end, build_cmd_opts)
 end
 

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -304,7 +304,6 @@ end
 
 local function move(src, dst)
     uv.fs_rename(src.dir, dst.dir)
-    dst.dir = src.dir
     dst.status = Status.INSTALLED
 end
 
@@ -417,7 +416,7 @@ end
 local function diff_populate()
     for name, lock_pkg in pairs(Lock) do
         local pack_pkg = Packages[name]
-        if lock_pkg and Filter.not_removed(lock_pkg) and not vim.deep_equal(lock_pkg, pack_pkg) then
+        if pack_pkg and Filter.not_removed(lock_pkg) and not vim.deep_equal(lock_pkg, pack_pkg) then
             for k, v in pairs {
                 dir = Status.TO_MOVE,
                 branch = Status.TO_RECLONE,
@@ -467,7 +466,6 @@ local paq = setmetatable({
         vim.tbl_map(register, pkgs)
         lock_load()
         diff_populate()
-        vim.print(Diff)
         return self
     end,
 })

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -94,6 +94,7 @@ local function lock_write()
         assert(uv.fs_write(file, result))
         assert(uv.fs_close(file))
     end
+    Lock = Packages
 end
 
 local function lock_load()
@@ -109,7 +110,8 @@ local function lock_load()
         end
     end
     lock_write()
-    return vim.deepcopy(Packages)
+    return Packages
+end
 end
 
 local function call_proc(process, args, cwd, cb, print_stdout)
@@ -160,7 +162,6 @@ local function clone(pkg, counter, build_queue)
         if ok then
             pkg.status = Status.CLONED
             lock_write()
-            Lock = vim.deepcopy(Packages)
             if pkg.build then
                 table.insert(build_queue, pkg)
             end
@@ -215,7 +216,6 @@ local function pull(pkg, counter, build_queue)
                 log_update_changes(pkg, prev_hash, cur_hash)
                 pkg.status = Status.UPDATED
                 lock_write()
-                Lock = vim.deepcopy(Packages)
                 counter(pkg.name, Messages.update, "ok")
                 if pkg.build then
                     table.insert(build_queue, pkg)
@@ -269,7 +269,6 @@ local function remove(p, counter)
     if ok then
         Packages[p.name] = { name = p.name, status = Status.REMOVED }
         lock_write()
-        Lock = vim.deepcopy(Packages)
     end
 end
 

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -304,7 +304,7 @@ end
 
 local function move(src, dst)
     uv.fs_rename(src.dir, dst.dir)
-    dst.dir = dst.dir
+    dst.dir = src.dir
     dst.status = Status.INSTALLED
 end
 

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -226,9 +226,10 @@ local function lock_load()
               pkg.build = Packages[name] and Packages[name].build or nil
             end
         end
+    else
+        lock_write()
+        Lock = Packages
     end
-    lock_write()
-    Lock = Packages
 end
 
 -- }}}

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -327,28 +327,27 @@ local function list()
     end
 end
 
-local function register(args)
-    if type(args) == "string" then
-        args = { args }
+local function register(pkg)
+    if type(pkg) == "string" then
+        pkg = { pkg }
     end
-    local url = args.url
-        or (args[1]:match("^https?://") and args[1])    -- [1] is a URL
-        or string.format(cfg.url_format, args[1])       -- [1] is a repository name
-    local name = args.as
-        or url:gsub("%.git$", ""):match("/([%w-_.]+)$") -- Infer name from `url`
+    local url = pkg.url
+        or (pkg[1]:match("^https?://") and pkg[1]) -- [1] is a URL
+        or string.format(cfg.url_format, pkg[1]) -- [1] is a repository name
+    local name = pkg.as or url:gsub("%.git$", ""):match("/([%w-_.]+)$") -- Infer name from `url`
     if not name then
-        return vim.notify(" Paq: Failed to parse " .. vim.inspect(args), vim.log.levels.ERROR)
+        return vim.notify(" Paq: Failed to parse " .. vim.inspect(pkg), vim.log.levels.ERROR)
     end
-    local opt = args.opt or cfg.opt and args.opt == nil
+    local opt = pkg.opt or cfg.opt and pkg.opt == nil
     local dir = cfg.path .. (opt and "opt/" or "start/") .. name
     packages[name] = {
         name = name,
-        branch = args.branch,
+        branch = pkg.branch,
         dir = dir,
         status = uv.fs_stat(dir) and status.INSTALLED or status.LISTED,
         hash = get_git_hash(dir),
-        pin = args.pin,
-        run = args.run, -- TODO(breaking): Rename
+        pin = pkg.pin,
+        run = pkg.run, -- TODO(breaking): Rename
         url = url,
     }
 end

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -223,7 +223,7 @@ local function lock_load()
             Lock = not vim.tbl_isempty(result) and result or Packages
             -- Repopulate 'build' key so 'vim.deep_equal' works
             for name, pkg in pairs(result) do
-              pkg.build = Packages[name].build
+              pkg.build = Packages[name] and Packages[name].build or nil
             end
         end
     end

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -382,14 +382,13 @@ local paq = setmetatable({
 })
 
 for cmd_name, fn in pairs {
-        PaqInstall = paq.install,
-        PaqUpdate = paq.update,
-        PaqClean = paq.clean,
-        PaqSync = paq.sync,
-        PaqList = paq.list,
-        PaqLogOpen = paq.log_open,
-        PaqLogClean = paq.log_clean,
-    }
+    PaqInstall = paq.install,
+    PaqUpdate = paq.update,
+    PaqClean = paq.clean,
+    PaqList = paq.list,
+    PaqLogOpen = paq.log_open,
+    PaqLogClean = paq.log_clean,
+}
 do
     vim.api.nvim_create_user_command(cmd_name, function(_) fn() end, { bar = true })
 end
@@ -402,6 +401,7 @@ do
         complete = function() return vim.tbl_keys(vim.tbl_map(function(pkg) return pkg.build end, packages)) end,
     }
     vim.api.nvim_create_user_command("PaqBuild", function(a) run_hook(Packages[a.args]) end, build_cmd_opts)
+    vim.api.nvim_create_user_command("PaqSync", function() paq:sync() end, { bar = true })
     vim.api.nvim_create_user_command("PaqRunHook", function(a)
         vim.deprecate("`PaqRunHook` command", "`PaqBuild`", "3.0", "Paq", false)
         run_hook(Packages[a.args])

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -365,6 +365,5 @@ return setmetatable({
     log_open = function() vim.cmd("sp " .. logfile) end,
     log_clean = function() return assert(uv.fs_unlink(logfile)) and vim.notify(" Paq: log file deleted") end,
     register = register,
-    paq = register, -- TODO: deprecate. not urgent
 }, {__call = function(self, tbl) packages = {} lock = lock_load() or packages vim.tbl_map(register, tbl) return self end,
 })

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -18,16 +18,15 @@ for var, val in pairs(uv.os_environ()) do
 end
 table.insert(env, "GIT_TERMINAL_PROMPT=0")
 
-vim.cmd([[
-    command! -bar PaqInstall  lua require('paq'):install()
-    command! -bar PaqUpdate   lua require('paq'):update()
-    command! -bar PaqClean    lua require('paq'):clean()
-    command! -bar PaqSync     lua require('paq'):sync()
-    command! -bar PaqList     lua require('paq').list()
-    command! -bar PaqLogOpen  lua require('paq').log_open()
-    command! -bar PaqLogClean lua require('paq').log_clean()
-    command! -bar -nargs=1 -complete=customlist,v:lua.require'paq'._get_hooks PaqRunHook lua require('paq')._run_hook(<f-args>)
-]])
+vim.api.nvim_create_user_command("PaqInstall", "lua require('paq'):install()", { bar = true })
+vim.api.nvim_create_user_command("PaqUpdate", "lua require('paq'):update()", { bar = true })
+vim.api.nvim_create_user_command("PaqClean", "lua require('paq'):clean()", { bar = true })
+vim.api.nvim_create_user_command("PaqSync", "lua require('paq'):sync()", { bar = true })
+vim.api.nvim_create_user_command("PaqList", "lua require('paq').list()", { bar = true })
+vim.api.nvim_create_user_command("PaqLogOpen", "lua require('paq').log_open()", { bar = true })
+vim.api.nvim_create_user_command("PaqLogClean", "lua require('paq').log_clean()", { bar = true })
+vim.api.nvim_create_user_command("PaqRunHook", function(a) require'paq'.run_hook(a.args) end,
+    { bar = true, nargs = 1, complete = function() return require'paq'._get_hooks() end })
 
 local function report(op, name, res, n, total)
     local messages = {
@@ -354,30 +353,16 @@ end
 
 -- stylua: ignore
 return setmetatable({
-    install = function() exe_op("install", clone,
-            vim.tbl_filter(function(pkg) return not pkg.exists and pkg.status ~= "removed" end, packages)) end,
-    update = function() exe_op("update", pull,
-            vim.tbl_filter(function(pkg) return pkg.exists and not pkg.pin end, packages)) end,
+    install = function() exe_op("install", clone, vim.tbl_filter(function(pkg) return not pkg.exists and pkg.status ~= status.REMOVED end, packages)) end,
+    update = function() exe_op("update", pull, vim.tbl_filter(function(pkg) return pkg.exists and not pkg.pin end, packages)) end,
     clean = function() exe_op("remove", remove, state_diff().lock) end,
-    sync = function(self)
-        self:clean()
-        exe_op("sync", clone_or_pull, vim.tbl_filter(function(pkg) return pkg.status ~= "removed" end, packages))
-    end,
-    setup = function(self, args)
-        for k, v in pairs(args) do cfg[k] = v end
-        return self
-    end,
+    sync = function(self) self:clean() exe_op("sync", clone_or_pull, vim.tbl_filter(function(pkg) return pkg.status ~= status.REMOVED end, packages)) end,
+    setup = function(self, args) for k, v in pairs(args) do cfg[k] = v end return self end,
     _run_hook = function(name) return run_hook(packages[name]) end,
     _get_hooks = function() return vim.tbl_keys(vim.tbl_map(function(pkg) return pkg.run end, packages)) end,
     list = list,
     log_open = function() vim.cmd("sp " .. logfile) end,
     log_clean = function() return assert(uv.fs_unlink(logfile)) and vim.notify(" Paq: log file deleted") end,
     register = register,
-}, {
-    __call = function(self, tbl)
-        packages = {}
-        lock = lock_load() or packages
-        vim.tbl_map(register, tbl)
-        return self
-    end,
+}, { __call = function(self, tbl) packages = {} lock = lock_load() or packages vim.tbl_map(register, tbl) return self end,
 })

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -5,6 +5,12 @@ local cfg = {
     verbose = false,
     url_format = "https://github.com/%s.git",
 }
+local status = {
+    LISTED = 0,
+    INSTALLED = 1,
+    UPDATED = 2,
+    REMOVED = 3,
+}
 local logpath = vim.fn.has("nvim-0.8") == 1 and vim.fn.stdpath("log") or vim.fn.stdpath("cache")
 local logfile = logpath .. "/paq.log"
 local lockfile = vim.fn.stdpath("data") .. "/paq-lock.json"
@@ -182,7 +188,7 @@ local function clone(pkg, counter, sync)
     call_proc("git", args, nil, function(ok)
         if ok then
             pkg.exists = true
-            pkg.status = "installed"
+            pkg.status = status.INSTALLED
             return pkg.run and run_hook(pkg, counter, sync) or counter(pkg.name, "ok", sync)
         else
             counter(pkg.name, "err", sync)
@@ -234,7 +240,7 @@ local function pull(pkg, counter, sync)
             local cur_hash = pkg.hash
             if cur_hash ~= prev_hash then
                 log_update_changes(pkg, prev_hash, cur_hash)
-                pkg.status = "updated"
+                pkg.status = status.UPDATED
                 return pkg.run and run_hook(pkg, counter, sync) or counter(pkg.name, "ok", sync)
             else
                 counter(pkg.name, "nop", sync)
@@ -284,7 +290,7 @@ local function remove(p, counter)
     local ok = rmdir(p.dir)
     counter(p.name, ok and "ok" or "err")
     if ok then
-        packages[p.name] = { name = p.name, status = "removed" }
+        packages[p.name] = { name = p.name, status = status.REMOVED }
     end
 end
 
@@ -310,10 +316,10 @@ end
 -- stylua: ignore
 local function list()
     local installed = vim.tbl_filter(function(pkg) return pkg.exists end, packages)
-    local removed = vim.tbl_filter(function(pkg) return pkg.status == "removed" end, lock)
+    local removed = vim.tbl_filter(function(pkg) return pkg.status == status.REMOVED end, lock)
     sort_by_name(installed)
     sort_by_name(removed)
-    local markers = { installed = "+", updated = "*" }
+    local markers = { "+", "*" }
     for header, pkgs in pairs { ["Installed packages:"] = installed, ["Recently removed:"] = removed } do
         if #pkgs ~= 0 then
             print(header)
@@ -343,7 +349,7 @@ local function register(args)
         branch = args.branch,
         dir = dir,
         exists = vim.fn.isdirectory(dir) ~= 0,
-        status = "listed", -- TODO: should probably merge this with `exists` in the future...
+        status = status.LISTED, -- TODO: should probably merge this with `exists` in the future...
         hash = get_git_hash(dir),
         pin = args.pin,
         run = args.run, -- TODO(breaking): Rename

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -431,6 +431,7 @@ local function diff_populate()
     end
 end
 
+
 local function diff_resolve()
     if not vim.tbl_isempty(Diff) then
         for name, diff_pkg in pairs(Diff) do
@@ -458,7 +459,6 @@ local paq = setmetatable({
     list = list,
     log_open = function() vim.cmd("sp " .. Config.log) end,
     log_clean = function() return assert(uv.fs_unlink(Config.log)) and vim.notify(" Paq: log file deleted") end,
-    register = register,
 }, {
     __call = function(self, pkgs)
         Packages = {}

--- a/test/test.lua
+++ b/test/test.lua
@@ -1,6 +1,5 @@
 local TESTPATH = vim.fn.stdpath("data") .. "/site/pack/test/"
 local uv = vim.loop
-local vim = require("paq.compat")
 
 package.loaded.paq = nil
 local paq = require("paq"):setup({ path = TESTPATH })
@@ -12,9 +11,9 @@ local PACKAGES = {
 
     { as = "wiki", url = "https://github.com/lervag/wiki.vim" }, -- test url + as
 
-    { "junegunn/fzf", run = vim.fn["fzf#install"] }, -- test run function
+    { "junegunn/fzf", build = vim.fn["fzf#install"] }, -- test build function
 
-    { "autozimu/LanguageClient-neovim", branch = "next", run = "bash install.sh" }, -- branch + run command
+    { "autozimu/LanguageClient-neovim", branch = "next", build = "bash install.sh" }, -- branch + build command
 }
 
 local function test_branch(paq, dir, branch)


### PR DESCRIPTION
### BREAKING CHANGES:

- The `run` option is deprecated. Use `build` instead.
- Similarly, the `PaqRunHook` is deprecated in favor of `PaqBuild`.
- The `paq`/`register` function was removed.

----

I think we are ready to ship paq 2.0. We need to made some small modifications but I think we are there.

I have some questions regarding the documentation. If we are gonna annotate the source with emmylua comment, what documentation generator we'll going to use? [mini.doc](https://github.com/echasnovski/mini.doc) or [lemmy-help](https://github.com/numToStr/lemmy-help)?

When I've tried do documentation with emmylua comments, I found myself unwrapping a lot of the code since parsers didn't play nicely with things such as metatables. Also is worth noting that most of the documentation, found in the `paq-nvim.txt`, doesn't really belong anywhere in the codebase. Leading to having pretty big wall of comments at the begin and end of the file and nothing in the middle.


----


- Closes #107
- Closes #73
- Closes #80
- Closes #99 
- Closes #150 