### PR TITLE
fix: retrieve new hash after pull and write it to lock file (#160)

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -306,10 +306,10 @@ local function pull(pkg, counter, build_queue)
         if not ok then
             counter(pkg.name, Messages.update, "err")
         else
-            local cur_hash = pkg.hash
+            local cur_hash = get_git_hash(pkg.dir)
             if cur_hash ~= prev_hash then
                 log_update_changes(pkg, prev_hash, cur_hash)
-                pkg.status = Status.UPDATED
+                pkg.status, pkg.hash = Status.UPDATED, cur_hash
                 lock_write()
                 counter(pkg.name, Messages.update, "ok")
                 if pkg.build then


### PR DESCRIPTION
The check to determine if a pkg was actually updated after a pull erroneously used the old pkg hash, even after pulling new commits. This pull request makes sure to use the new hash and also write it to the lock file.