### PR TITLE
feat: adding query method to paq

### DIFF
--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -213,6 +213,15 @@ imported as `paq`, the functions are:
   }
 
 
+|paq.query|                                                        *paq-query*
+
+  Queries paq's packages storage with predefined
+  filters by passing one of the following strings:
+  - "installed"
+  - "to_install"
+  - "to_update"
+
+
 ==============================================================================
 PACKAGE OPTIONS                                                  *paq-options*
 

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -537,6 +537,20 @@ function paq:setup(opts)
     return self
 end
 
+---Queries paq's packages storage with predefined
+---filters by passing one of the following strings:
+--- - "installed"
+--- - "to_install"
+--- - "to_update"
+---@param filter string
+function paq.query(filter)
+    vim.validate({ filter = { filter, { 'string' } } })
+    if not Filter[filter] then
+        error(string.format("No filter with name: %q", filter))
+    end
+    return vim.deepcopy(vim.tbl_filter(Filter[filter], Packages))
+end
+
 function paq.list()
     local installed = vim.tbl_filter(Filter.installed, Lock)
     local removed = vim.tbl_filter(Filter.removed, Lock)


### PR DESCRIPTION
Related to: #164 

This little new method let's query paq's registry of packages to let the user have custom functionality like notify if the are packages to install at startup.

### Example

Notify user when there are new packages to install.

```lua
vim.api.nvim_create_autocmd("VimEnter", {
	once = true,
	callback = function() 
            local pkgs_count = #require("paq").query("to_install")
            if pkgs_count < 1 then return end
	    print(string.format("There are %d to install", pkgs_count))
	end
})
```

You can even setup automatic packages installation at startup.

```lua
vim.api.nvim_create_autocmd("VimEnter", {
	once = true,
	callback = function() 
            local pkgs_count = #require("paq").query("to_install")
            if pkgs_count < 1 then return end
            require("paq").install()
	end
})
```