### PR TITLE
fix: error in nightly from renamed uv module

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -2,7 +2,7 @@
 
 ---@alias Path string
 
-local uv = vim.loop
+local uv = vim.uv or vim.loop
 
 ---@class setup_opts
 ---@field path Path


### PR DESCRIPTION
Fix: #166

Now in neovim nightly the uv module is called 'vim.uv' instead of 'vim.loop'. This coused some problems with some operations.