### PR TITLE
[FIX] (logging): use directly the file descriptor of the opened log

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -110,15 +110,12 @@ end
 ---@param print_stdout boolean?
 local function run(process, args, cwd, cb, print_stdout)
     local log = uv.fs_open(Config.log, "a+", 0x1A4)
-    local stderr = uv.new_pipe(false)
-    stderr:open(log)
     local handle, pid
     handle, pid = uv.spawn(
         process,
-        { args = args, cwd = cwd, stdio = { nil, print_stdout and stderr, stderr }, env = Env },
+        { args = args, cwd = cwd, stdio = { nil, print_stdout and log, log }, env = Env },
         vim.schedule_wrap(function(code)
             uv.fs_close(log)
-            stderr:close()
             handle:close()
             cb(code == 0)
         end)


### PR DESCRIPTION
Use directly the file descriptor of the opened log file instead of an intermediate pipe as uv.spawn supports the former for stdio.
On windows 11 Arm 64 the log file is not populated otherwise. It might be a bug in libuv implementation but, since the documentation of "uv.spawn" mentions that file descriptors can be used for stdio we can skip the intermediate pipe.