### PR TITLE
fix: use `normal!` with bang in `paq.log_open`

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -539,7 +539,7 @@ end
 
 function paq.log_open()
     vim.cmd.split(Config.log)
-    vim.cmd("silent! normal G")
+    vim.cmd("silent! normal! G")
 end
 
 function paq.log_clean()


### PR DESCRIPTION
Remappings of `G` should be ignored.