### PR TITLE
fix: Fast API cannot be used in vim.system callback

### DIFF
--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -324,7 +324,7 @@ local function run_build(pkg)
         vim.system(
             args,
             { cwd = pkg.dir },
-            function(obj) report(pkg.name, Messages.build, obj.code == 0 and "ok" or "err") end
+            vim.schedule_wrap(function(obj) report(pkg.name, Messages.build, obj.code == 0 and "ok" or "err") end)
         )
     end
 end


### PR DESCRIPTION
Since `vim.notify` is just a wrapper of `nvim_echo()`, it cannot be used as `vim.system()` callback (vim.system() itself is also a wrapper of `vim.uv`). To solve it, I wrap it with `vim.schedule_wrap()`