### PR TITLE
feat: Adds a PaqWait command

### DIFF
--- a/doc/paq-nvim.txt
+++ b/doc/paq-nvim.txt
@@ -132,6 +132,12 @@ imported as `paq`, the functions are:
   for other debugging purposes.
 
 
+|PaqWait|                                                           *:PaqWait*
+  Waits for any previous Paq operations to complete before continuing.
+  This is useful in scripts or autocommands where you need to ensure that
+  all package operations have finished before proceeding.
+
+
 |paq.list|                                                          *paq.list*
                                                                   *:PaqList*
   Lists installed packages as well as packages that were recently removed.

--- a/lua/paq.lua
+++ b/lua/paq.lua
@@ -598,6 +598,17 @@ do
                 :totable()
         end,
     })
+
+    -- Paq operations are async by default, which is good but hard to script with.
+    vim.api.nvim_create_user_command("PaqWait", function()
+        local done = false
+        vim.api.nvim_create_autocmd("User", {
+            pattern = "PaqDone*",
+            once = true,
+            callback = function() done = true end,
+        })
+        vim.wait(120000, function() return done end, 100)
+    end, { bar = true })
 end
 
 return paq


### PR DESCRIPTION
This minimally enables scripting usecases. Currently `vim.system` calls used in various Paq* commands are async and we have to setup autocommand hooks to wait which is not ideal.

For example, I have an auto update script like this:

    nvim --headless +PaqInstall +PaqWait +qall!

This doesn't work without `+PaqWait` and I have to write a wrapper in lua.

---

Some approaches I have considered:
* Write the wrapper in my own inits -> Looks like a clunky patch.
* Refactoring the commands to accept `async = true` style parameters -> Seems non-trivial and might break api.
* Adds alternate `:PaqInstallSync` command -> This would adds quite a bit of duplication and I think it doesn't follow your philosophy of keep paq minimal.